### PR TITLE
Bug ao gerar a documentação swagger com os links

### DIFF
--- a/src/main/java/com/algaworks/algafood/core/springfox/SpringFoxHalSupport.java
+++ b/src/main/java/com/algaworks/algafood/core/springfox/SpringFoxHalSupport.java
@@ -1,0 +1,14 @@
+package com.algaworks.algafood.core.springfox;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.stereotype.Component;
+import springfox.documentation.schema.configuration.ObjectMapperConfigured;
+
+@Component
+public class SpringFoxHalSupport implements ApplicationListener<ObjectMapperConfigured> {
+    @Override
+    public void onApplicationEvent(ObjectMapperConfigured event) {
+        event.getObjectMapper().registerModule(new Jackson2HalModule());
+    }
+}


### PR DESCRIPTION
O esperado é que os links sejam serializados na documentação com o nome “_links” porém estavam sendo serializados como “links”.